### PR TITLE
faster benchmarks

### DIFF
--- a/test_zonal_stat.jl
+++ b/test_zonal_stat.jl
@@ -11,6 +11,8 @@ using ThreadTools
 
 println(" nthreads = ", Threads.nthreads())
 
+# Define a `zonal` function to do arbitrary zonal stats (should we include this in Rasters.jl?)
+zonal(f, raster, geom) = map(x -> f(skipmissing(mask(crop(dem_model; to=x); with=x))), geom)
 
 md"""
 # Open the vector geojson files for the villages in Taiwan
@@ -35,8 +37,14 @@ dem_models = map(x->read(Raster(x)), filter(x->occursin("n24", x),readdir("./DEM
 dem_mosaic = mosaic(first, dem_models...)
 @btime mosaic(first, dem_models...)
 
- mean_height_wufeng = tmap(x -> mean(skipmissing(replace_missing(mask(dem_model; to=x)))), villages_wufeng.geom)
-@btime map(x -> mean(skipmissing(replace_missing(mask(dem_model; to=x)))), villages_wufeng.geom)
+# But this is MUCH faster. Rasters.jl could detect that
+# these are tiles that match and dont overlap,
+# and use `cat` for `mosaic` as well.
+dem_mosaic = cat(dem_models...; dims=X)
+@btime dem_mosaic = cat(dem_models...; dims=X)
+
+mean_height_wufeng = zonal(mean, dem_mosaic, villages_wufeng.geom)
+@btime mean_height_wufeng = zonal(mean, $dem_mosaic, $villages_wufeng.geom)
 
 insertcols!(villages_wufeng, 1, :mean_heigth => mean_height_wufeng)
 GDF.write("wufeng.gpkg", villages_wufeng)


### PR DESCRIPTION
Hi @Meresmata,

With the latest Rasters.jl and some different method choices the Rasters.jl part of this should be quite a few orders of magnitude faster, mostly by using `crop` before doing anything else. 

(I also just realised that there is a DimensionalData.jl bug that `mosaic` now hits for your specific raster files, which is unfortunate but should be fixed soon)